### PR TITLE
Change the either dependency to <4.5

### DIFF
--- a/thumbnail-plus.cabal
+++ b/thumbnail-plus.cabal
@@ -57,7 +57,7 @@ library
     data-default      >= 0.5,
 
     transformers      >= 0.3,
-    either            >= 4.1,
+    either            >= 4.1 && < 4.5,
 
     conduit           >= 1.1,
     conduit-extra     >= 1.1,


### PR DESCRIPTION
Basically, version 5 tells you to go use the transmormers package and
their Except monad and 4.5 tells you that it's deprecated, but 4.4.1.1
works alright